### PR TITLE
colorselector plugin fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ provide emacs-like colorscheme selector buffer.
 Commands
 ========
 
-      :SelectColorS  
+      :SelectColorS
 
       :EditCurrentColorS
 
@@ -18,9 +18,9 @@ BufferMapping
 
 *e*    - edit
 
-*j*    - apply next
+*C-n*  - apply next
 
-*k*    - apply previous
+*C-p*  - apply previous
 
 *R*    - fetch new random scheme
 

--- a/plugin/colorselector.vim
+++ b/plugin/colorselector.vim
@@ -144,8 +144,8 @@ endf
 fun! s:help()
   echo "** ColorScheme Selector **"
   echo "  e    - edit"
-  echo "  j    - apply next"
-  echo "  k    - apply previous"
+  echo "  C-n  - apply next"
+  echo "  C-p  - apply previous"
   echo "  R    - fetch new random scheme"
   echo "  D    - delete scheme"
   echo "  ?    - show help"


### PR DESCRIPTION
Hi c9s:

Thanks for this plugin, I just made a few bug fixes. It should solve the following issues:
1. Fixed regexp for color schema filename. It can recognize file name like '256-jungle.vim' now.
2. Fixed cross platform issue. It can use under windows/linux without any modification now.
3. Some document fixed.

Regards, Mark
